### PR TITLE
Set release version dynamically

### DIFF
--- a/src/BecklynMonitoringBundle.php
+++ b/src/BecklynMonitoringBundle.php
@@ -4,12 +4,27 @@ namespace Becklyn\Monitoring;
 
 use Becklyn\AssetsBundle\Namespaces\RegisterAssetNamespacesCompilerPass;
 use Becklyn\Monitoring\DependencyInjection\BecklynMonitoringExtension;
+use Becklyn\Monitoring\DependencyInjection\CompilerPass\ReleaseVersionPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 
 class BecklynMonitoringBundle extends Bundle
 {
+    /**
+     * @var ReleaseVersionPass
+     */
+    private $releaseVersionPass;
+
+
+    /**
+     *
+     */
+    public function __construct ()
+    {
+        $this->releaseVersionPass = new ReleaseVersionPass();
+    }
+
     /**
      * @inheritDoc
      */
@@ -20,6 +35,8 @@ class BecklynMonitoringBundle extends Bundle
                 "monitoring" => __DIR__ . "/../build",
             ])
         );
+
+        $container->addCompilerPass($this->releaseVersionPass);
     }
 
 
@@ -28,6 +45,6 @@ class BecklynMonitoringBundle extends Bundle
      */
     public function getContainerExtension ()
     {
-        return new BecklynMonitoringExtension();
+        return new BecklynMonitoringExtension($this->releaseVersionPass);
     }
 }

--- a/src/DependencyInjection/CompilerPass/ReleaseVersionPass.php
+++ b/src/DependencyInjection/CompilerPass/ReleaseVersionPass.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Becklyn\Monitoring\DependencyInjection\CompilerPass;
+
+use Becklyn\Hosting\Git\GitIntegration;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+
+class ReleaseVersionPass implements CompilerPassInterface
+{
+    /**
+     * @var string
+     */
+    private $projectName;
+
+
+    /**
+     * @param mixed $projectName
+     */
+    public function setProjectName (string $projectName) : void
+    {
+        $this->projectName = $projectName;
+    }
+
+
+
+    /**
+     * @inheritDoc
+     */
+    public function process (ContainerBuilder $container)
+    {
+        $git = new GitIntegration($container->getParameter('kernel.project_dir'));
+        $version = $git->fetchHeadCommitHash() ?? "?";
+
+        $container->getDefinition("sentry.client")
+            ->addMethodCall("setRelease", ["{$this->projectName}@{$version}"]);
+    }
+}


### PR DESCRIPTION
As we need the project name there


Background: https://docs.sentry.io/workflow/releases/

> Note that releases are global per organization so make sure to prefix them with something project specific if needed:
> 
>     Sentry.init({
>       release: "my-project-name@2.3.12"
>     })